### PR TITLE
Update dependencies with outdated names

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,49 +11,49 @@ tokio = "0.1.7"
 futures = "0.1"
 exit-future = "0.1"
 jsonrpc-core = "13.0.0"
-cli = { package = "substrate-cli", git = "https://github.com/paritytech/substrate" }
+cli = { package = "sc-cli", git = "https://github.com/paritytech/substrate" }
 codec = { package = "parity-scale-codec", version = "1.0.0" }
-sr-io = { git = "https://github.com/paritytech/substrate" }
-client = { package = "substrate-client", git = "https://github.com/paritytech/substrate" }
 primitives = { package = "substrate-primitives", git = "https://github.com/paritytech/substrate" }
-inherents = { package = "substrate-inherents", git = "https://github.com/paritytech/substrate" }
+sp-io = { git = "https://github.com/paritytech/substrate" }
+client = { package = "sc-client", git = "https://github.com/paritytech/substrate" }
+inherents = { package = "sp-inherents", git = "https://github.com/paritytech/substrate" }
 node-runtime = { path = "../runtime" }
 node-rpc = { path = "../rpc" }
 node-primitives = { path = "../primitives" }
 hex-literal = "0.2"
-substrate-rpc = { package = "substrate-rpc", git = "https://github.com/paritytech/substrate" }
+substrate-rpc = { package = "sp-rpc", git = "https://github.com/paritytech/substrate" }
 substrate-basic-authorship = { git = "https://github.com/paritytech/substrate" }
 substrate-service = { git = "https://github.com/paritytech/substrate" }
-transaction_pool = { package = "substrate-transaction-pool", git = "https://github.com/paritytech/substrate" }
-network = { package = "substrate-network", git = "https://github.com/paritytech/substrate" }
-babe = { package = "substrate-consensus-babe", git = "https://github.com/paritytech/substrate" }
-babe-primitives = { package = "substrate-consensus-babe-primitives", git = "https://github.com/paritytech/substrate" }
-grandpa = { package = "substrate-finality-grandpa", git = "https://github.com/paritytech/substrate" }
-grandpa_primitives = { package = "substrate-finality-grandpa-primitives", git = "https://github.com/paritytech/substrate" }
+transaction_pool = { package = "sp-transaction-pool", git = "https://github.com/paritytech/substrate" }
+network = { package = "sc-network", git = "https://github.com/paritytech/substrate" }
+babe = { package = "sc-consensus-babe", git = "https://github.com/paritytech/substrate" }
+babe-primitives = { package = "sp-consensus-babe", git = "https://github.com/paritytech/substrate" }
+grandpa = { package = "sc-finality-grandpa", git = "https://github.com/paritytech/substrate" }
+grandpa_primitives = { package = "sp-finality-grandpa", git = "https://github.com/paritytech/substrate" }
 sr-primitives = { git = "https://github.com/paritytech/substrate" }
 node-executor = { path = "../executor" }
-substrate-telemetry = { package = "substrate-telemetry", git = "https://github.com/paritytech/substrate" }
+substrate-telemetry = { package = "sp-telemetry", git = "https://github.com/paritytech/substrate" }
 structopt = "0.2"
 transaction-factory = { git = "https://github.com/paritytech/substrate" }
-keyring = { package = "substrate-keyring", git = "https://github.com/paritytech/substrate" }
-indices = { package = "srml-indices", git = "https://github.com/paritytech/substrate" }
-timestamp = { package = "srml-timestamp", git = "https://github.com/paritytech/substrate", default-features = false }
+keyring = { package = "sp-keyring", git = "https://github.com/paritytech/substrate" }
+indices = { package = "pallet-indices", git = "https://github.com/paritytech/substrate" }
+timestamp = { package = "pallet-timestamp", git = "https://github.com/paritytech/substrate", default-features = false }
 rand = "0.6"
-finality_tracker = { package = "srml-finality-tracker", git = "https://github.com/paritytech/substrate", default-features = false }
-contracts = { package = "srml-contracts", git = "https://github.com/paritytech/substrate" }
-system = { package = "srml-system", git = "https://github.com/paritytech/substrate" }
-balances = { package = "srml-balances", git = "https://github.com/paritytech/substrate" }
-support = { package = "srml-support", git = "https://github.com/paritytech/substrate", default-features = false }
-im_online = { package = "srml-im-online", git = "https://github.com/paritytech/substrate", default-features = false }
+finality_tracker = { package = "pallet-finality-tracker", git = "https://github.com/paritytech/substrate", default-features = false }
+contracts = { package = "pallet-contracts", git = "https://github.com/paritytech/substrate" }
+system = { package = "pallet-system", git = "https://github.com/paritytech/substrate" }
+balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate" }
+support = { package = "pallet-support", git = "https://github.com/paritytech/substrate", default-features = false }
+im_online = { package = "pallet-im-online", git = "https://github.com/paritytech/substrate", default-features = false }
 
 [dev-dependencies]
-keystore = { package = "substrate-keystore", git = "https://github.com/paritytech/substrate" }
-babe = { package = "substrate-consensus-babe", git = "https://github.com/paritytech/substrate", features = ["test-helpers"] }
-consensus-common = { package = "substrate-consensus-common", git = "https://github.com/paritytech/substrate" }
-service-test = { package = "substrate-service-test", git = "https://github.com/paritytech/substrate" }
+keystore = { package = "sp-keystore", git = "https://github.com/paritytech/substrate" }
+babe = { package = "sc-babe", git = "https://github.com/paritytech/substrate", features = ["test-helpers"] }
+consensus-common = { package = "sc-common", git = "https://github.com/paritytech/substrate" }
+service-test = { package = "sp-service-test", git = "https://github.com/paritytech/substrate" }
 futures03 = { package = "futures-preview", version = "0.3.0-alpha.17" }
 tempfile = "3.1"
 
 [build-dependencies]
-cli = { package = "substrate-cli", git = "https://github.com/paritytech/substrate" }
+cli = { package = "sc-cli", git = "https://github.com/paritytech/substrate" }
 structopt = "0.2"


### PR DESCRIPTION
Not complete yet, so still requires further package name updates, but a good portion of the packages that have had name changes by Parity have now been updated to reflect the new names.